### PR TITLE
Disable Qbs project

### DIFF
--- a/stoiridh-controls.qbs
+++ b/stoiridh-controls.qbs
@@ -20,8 +20,9 @@ import qbs 1.0
 
 Project {
     name: "Stoiridh.Controls"
-    minimumQbsVersion: '1.4.4'
+    minimumQbsVersion: '1.5.0'
     qbsSearchPaths: ['config/qbs']
+    condition: false
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //  References                                                                                //


### PR DESCRIPTION
The Qbs project is disabled until the issue #28 is fixed.

note: Update the minimum version required to 1.5.0.