### PR TITLE
Remove the explicit inclusion of the version number from the #include directives

### DIFF
--- a/src/controls/plugin.cpp
+++ b/src/controls/plugin.cpp
@@ -21,7 +21,7 @@
 #include <StoiridhControlsTemplates/Control>
 #include <StoiridhControlsTemplates/Padding>
 
-#include <StoiridhControlsTemplates/0.1.0/private/bootstrap/qmlextensionplugin_p.hpp>
+#include <StoiridhControlsTemplates/private/bootstrap/qmlextensionplugin_p.hpp>
 
 #include <QtQml/qqml.h>
 

--- a/src/templates/CMakeLists.txt
+++ b/src/templates/CMakeLists.txt
@@ -140,6 +140,14 @@ target_compile_definitions(${STOIRIDH_PROJECT_NAME}
 if(STOIRIDH_PROJECT_TESTING_ENABLE_INTERNAL)
     target_compile_definitions(${STOIRIDH_PROJECT_NAME}
         PRIVATE SCT_BUILD_INTERNAL_API SCT_INTERNAL_LIB)
+
+    # temporary fix: include directory for the access to the internal and private API in order to
+    #                build the projects.
+    string(CONCAT PRIVATE_INCLUDE_DIR "${STOIRIDH_INSTALL_ROOT}/${STOIRIDH_INSTALL_INCLUDE_DIR}"
+                                      "/${STOIRIDH_PROJECT_NAME}/${PROJECT_VERSION}")
+    target_include_directories(${STOIRIDH_PROJECT_NAME}
+        INTERFACE $<BUILD_INTERFACE:${PRIVATE_INCLUDE_DIR}>)
+    unset(PRIVATE_INCLUDE_DIR)
 endif()
 
 target_include_directories(${STOIRIDH_PROJECT_NAME}

--- a/src/templates/api/public/Control
+++ b/src/templates/api/public/Control
@@ -1,1 +1,1 @@
-#include "StoiridhControlsTemplates/0.1.0/public/control.hpp"
+#include "StoiridhControlsTemplates/0.1.0/StoiridhControlsTemplates/public/control.hpp"

--- a/src/templates/api/public/Core/Exception/Exception
+++ b/src/templates/api/public/Core/Exception/Exception
@@ -1,1 +1,1 @@
-#include "StoiridhControlsTemplates/0.1.0/public/core/exception/exception.hpp"
+#include "StoiridhControlsTemplates/0.1.0/StoiridhControlsTemplates/public/core/exception/exception.hpp"

--- a/src/templates/api/public/Core/Exception/ExceptionHandler
+++ b/src/templates/api/public/Core/Exception/ExceptionHandler
@@ -1,1 +1,1 @@
-#include "StoiridhControlsTemplates/0.1.0/public/core/exception/exceptionhandler.hpp"
+#include "StoiridhControlsTemplates/0.1.0/StoiridhControlsTemplates/public/core/exception/exceptionhandler.hpp"

--- a/src/templates/api/public/Core/Exception/NullPointerException
+++ b/src/templates/api/public/Core/Exception/NullPointerException
@@ -1,1 +1,1 @@
-#include "StoiridhControlsTemplates/0.1.0/public/core/exception/nullpointerexception.hpp"
+#include "StoiridhControlsTemplates/0.1.0/StoiridhControlsTemplates/public/core/exception/nullpointerexception.hpp"

--- a/src/templates/api/public/Padding
+++ b/src/templates/api/public/Padding
@@ -1,1 +1,1 @@
-#include "StoiridhControlsTemplates/0.1.0/public/padding.hpp"
+#include "StoiridhControlsTemplates/0.1.0/StoiridhControlsTemplates/public/padding.hpp"

--- a/src/templates/api/public/global.hpp
+++ b/src/templates/api/public/global.hpp
@@ -1,1 +1,1 @@
-#include "StoiridhControlsTemplates/0.1.0/public/global.hpp"
+#include "StoiridhControlsTemplates/0.1.0/StoiridhControlsTemplates/public/global.hpp"

--- a/tests/auto/templates/internal/style/abstractstyledispatcher/tst_sct_abstractstyledispatcher.cpp
+++ b/tests/auto/templates/internal/style/abstractstyledispatcher/tst_sct_abstractstyledispatcher.cpp
@@ -18,9 +18,9 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 #include <QtTest>
 
-#include <StoiridhControlsTemplates/0.1.0/internal/style/abstractstyledispatcher.hpp>
-#include <StoiridhControlsTemplates/0.1.0/internal/style/style.hpp>
-#include <StoiridhControlsTemplates/0.1.0/internal/style/styledispatcher.hpp>
+#include <StoiridhControlsTemplates/internal/style/abstractstyledispatcher.hpp>
+#include <StoiridhControlsTemplates/internal/style/style.hpp>
+#include <StoiridhControlsTemplates/internal/style/styledispatcher.hpp>
 
 namespace SCT = StoiridhControlsTemplates;
 

--- a/tests/auto/templates/internal/style/stylepropertychanges/tst_sct_stylepropertychanges.cpp
+++ b/tests/auto/templates/internal/style/stylepropertychanges/tst_sct_stylepropertychanges.cpp
@@ -19,7 +19,7 @@
 #include <QtTest>
 #include <QtQuick/QQuickItem>
 
-#include <StoiridhControlsTemplates/0.1.0/internal/style/stylepropertychanges.hpp>
+#include <StoiridhControlsTemplates/internal/style/stylepropertychanges.hpp>
 
 namespace SCT = StoiridhControlsTemplates;
 

--- a/tests/auto/templates/internal/style/stylepropertyexpression/tst_sct_stylepropertyexpression.cpp
+++ b/tests/auto/templates/internal/style/stylepropertyexpression/tst_sct_stylepropertyexpression.cpp
@@ -23,7 +23,7 @@
 #include <StoiridhControlsTemplates/Control>
 #include <StoiridhControlsTemplates/Core/Exception/NullPointerException>
 
-#include <StoiridhControlsTemplates/0.1.0/internal/style/stylepropertyexpression.hpp>
+#include <StoiridhControlsTemplates/internal/style/stylepropertyexpression.hpp>
 
 #include <stdexcept>
 

--- a/tests/auto/templates/internal/style/stylestatecontroller/tst_sct_stylestatecontroller.cpp
+++ b/tests/auto/templates/internal/style/stylestatecontroller/tst_sct_stylestatecontroller.cpp
@@ -24,8 +24,8 @@
 #include <StoiridhControlsTemplates/Control>
 #include <StoiridhControlsTemplates/Core/Exception/NullPointerException>
 
-#include <StoiridhControlsTemplates/0.1.0/internal/style/style.hpp>
-#include <StoiridhControlsTemplates/0.1.0/internal/style/stylestatecontroller.hpp>
+#include <StoiridhControlsTemplates/internal/style/style.hpp>
+#include <StoiridhControlsTemplates/internal/style/stylestatecontroller.hpp>
 
 namespace SCT = StoiridhControlsTemplates;
 

--- a/tests/auto/templates/internal/style/stylestateoperation/tst_sct_stylestateoperation.cpp
+++ b/tests/auto/templates/internal/style/stylestateoperation/tst_sct_stylestateoperation.cpp
@@ -24,7 +24,7 @@
 #include <StoiridhControlsTemplates/Control>
 #include <StoiridhControlsTemplates/Core/Exception/NullPointerException>
 
-#include <StoiridhControlsTemplates/0.1.0/internal/style/stylestateoperation.hpp>
+#include <StoiridhControlsTemplates/internal/style/stylestateoperation.hpp>
 
 namespace SCT = StoiridhControlsTemplates;
 


### PR DESCRIPTION
This changes will avoid to always update the #include directives when a new version will release.

submodules: 
    - StoiridhCMakeTools: updated

Task-number: #30 