### PR TITLE
Fix an issue about style updating

### DIFF
--- a/src/templates/control.cpp
+++ b/src/templates/control.cpp
@@ -273,8 +273,11 @@ void ControlPrivate::setStyle(StoiridhControlsTemplates::Style *style)
 
 void ControlPrivate::updateStyle()
 {
-    auto *const d_style = StylePrivate::get(style());
-    accept(d_style->styleDispatcher());
+    if (auto *const s = style())
+    {
+        auto *const d_style = StylePrivate::get(s);
+        accept(d_style->styleDispatcher());
+    }
 }
 
 QString ControlPrivate::styleState() const


### PR DESCRIPTION
A SIGSEV signal was triggered when a control template would want to update its style. But, a control template has not any style attached by
default.